### PR TITLE
Fixed guzzlehttp dependency issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2",
+        "guzzlehttp/guzzle": "^6.2 || ^7.0",
         "docusign/esign-client": "^6.1.0"
     },
     "require-dev": {


### PR DESCRIPTION
### Fixed
- Issue - [`#2`](https://github.com/docusign/docusign-esign-php-laravel/issues/2):  guzzlehttp/guzzle is outdated.